### PR TITLE
Update `props` argument for renderBase prop

### DIFF
--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -394,7 +394,7 @@ export default class Dropdown extends PureComponent {
     let { label = value } = this.selectedItem() || {};
 
     if ('function' === typeof renderBase) {
-      return renderBase({ ...props, label, value, renderAccessory });
+      return renderBase({ props, label, value, renderAccessory });
     }
 
     let title = null == label || 'string' === typeof label?


### PR DESCRIPTION
There's an undocumented prop, `renderBase`, that accepts a function that can be used to render code for the `TextInput` rendered.  The prop is currently called like so:
```javascript
if ('function' === typeof renderBase) {
  return renderBase({ ...props, label, value, renderAccessory });
}
```
The problem with using `...props` is that anyone defining their function for the prop now has to specify each key inside props in their function signature. 

This pull request removes the `...` from the call:

```javascript
if ('function' === typeof renderBase) {
  return renderBase({ props, label, value, renderAccessory });
}
```

which allows the prop to be defined like so:

```jsx
<Dropdown
  label="What's your favorite color?"
  data={[{value: "red"}, {value: "green"}]}
  value={this.props.value}
  onChangeText={this.handleChangeText}
  renderBase={(props, label, value, renderAccessory) => {
    // insert special render code
  }}
/>
```