### PR TITLE
Better control over ripple and animation durations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,8 @@ class Example extends Component {
 :----------------- |:--------------------------------------------- | --------:|:------------------
  label             | Text field label text (required)              |   String | -
  error             | Text field error text                         |   String | -
- animationDuration | Text field animation duration in ms           |   Number | 225
+ animationDuration | Dropdown opacity animation duration in ms     |   Number | 225
+ animationDelay    | Dropdown opacity animation delay in ms        |   Number | 225
  fontSize          | Text field font size                          |   Number | 16
  labelFontSize     | Text field label font size                    |   Number | 12
  labelHeight       | Text field label height                       |   Number | 32
@@ -85,9 +86,11 @@ class Example extends Component {
  containerStyle    | Styles for container view                     |   Object | -
  pickerStyle       | Styles for item picker view                   |   Object | -
  shadeOpacity      | Shade opacity for dropdown items              |   Number | 0.12
+ rippleDisabled    | Disable the ripple effect                     |  Boolean | false
  rippleOpacity     | Opacity for ripple effect                     |   Number | 0.54
  rippleInsets      | Insets for ripple on base component           |   Object | { top: 16, bottom: -8 }
  rippleCentered    | Ripple on base component should be centered   |  Boolean | false
+ rippleDuration    | Duration of the ripple effect                 |   Number | 450
  renderBase        | Render base component                         | Function | -
  renderAccessory   | Render text field accessory                   | Function | -
  valueExtractor    | Extract value from item (args: item, index)   | Function | ({ value }) => value

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -18,6 +18,10 @@ import { TextField } from 'react-native-material-textfield';
 import DropdownItem from '../item';
 import styles from './styles';
 
+
+
+const DefaultAnimationDuration = 225;
+
 export default class Dropdown extends PureComponent {
   static defaultProps = {
     hitSlop: { top: 6, right: 4, bottom: 6, left: 4 },
@@ -36,8 +40,10 @@ export default class Dropdown extends PureComponent {
       max: 16,
     },
 
+    rippleDisabled: false,
     rippleCentered: false,
     rippleSequential: true,
+    rippleDuration: DefaultAnimationDuration * 2,
 
     rippleInsets: {
       top: 16,
@@ -49,7 +55,8 @@ export default class Dropdown extends PureComponent {
     rippleOpacity: 0.54,
     shadeOpacity: 0.12,
 
-    animationDuration: 225,
+    animationDuration: DefaultAnimationDuration,
+    animationDelay: DefaultAnimationDuration,
     fontSize: 16,
 
     textColor: 'rgba(0, 0, 0, .87)',
@@ -108,6 +115,7 @@ export default class Dropdown extends PureComponent {
     shadeOpacity: PropTypes.number,
 
     animationDuration: PropTypes.number,
+    animationDelay: PropTypes.number,
     fontSize: PropTypes.number,
 
     textColor: PropTypes.string,
@@ -187,7 +195,9 @@ export default class Dropdown extends PureComponent {
       itemPadding,
       dropdownMargins: { min: minMargin, max: maxMargin },
       dropdownPosition,
+      rippleDisabled,
       animationDuration,
+      animationDelay,
       absoluteRTLLayout,
     } = this.props;
 
@@ -205,7 +215,7 @@ export default class Dropdown extends PureComponent {
       event.nativeEvent.locationY -= this.rippleInsets().top;
 
       /* Start ripple directly from event */
-      this.ripple.startRipple(event);
+      !rippleDisabled && this.ripple.startRipple(event);
     }
 
     if (!itemCount) {
@@ -228,7 +238,8 @@ export default class Dropdown extends PureComponent {
         x = dimensions.width - (x + containerWidth);
       }
 
-      let delay = Math.max(0, animationDuration - (Date.now() - timestamp));
+      let measureTime = Date.now() - timestamp;
+      let delay = Math.max(0, animationDelay - measureTime);
       let selected = this.selectedIndex();
       let offset = 0;
 
@@ -462,6 +473,8 @@ export default class Dropdown extends PureComponent {
     let {
       baseColor,
       animationDuration,
+      rippleDisabled,
+      rippleDuration,
       rippleOpacity,
       rippleCentered,
       rippleSequential,
@@ -477,9 +490,10 @@ export default class Dropdown extends PureComponent {
 
     return (
       <Ripple
+        disabled={rippleDisabled}
         style={style}
         rippleColor={baseColor}
-        rippleDuration={animationDuration * 2}
+        rippleDuration={rippleDuration}
         rippleOpacity={rippleOpacity}
         rippleCentered={rippleCentered}
         rippleSequential={rippleSequential}
@@ -487,6 +501,7 @@ export default class Dropdown extends PureComponent {
       />
     );
   }
+
 
   renderAccessory() {
     let { baseColor: backgroundColor } = this.props;


### PR DESCRIPTION
Current implementation does not provide enough control over Ripple effect.

In particular, the ripple effect should not be based on the dropdown opacity animation duration but rather have its own duration.
That's also the case for the animation delay.

For example, if I want to disable totally the Ripple effect, I currently have no choice than setting opacity 0 to the ripple effect. But this is not enough, because of the delay, the first feedback the user see is delayed. And I don't want to set the opacity animation to 0 to remove that delay.

This PR permit to easily disable the ripple effect, and decouple ripple animation duration from dropdown opacity animation duration