### PR TITLE
Don't worry about dropdownPosition during resetScrollOffset()

### DIFF
--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -413,30 +413,20 @@ export default class Dropdown extends PureComponent {
     let visibleItemCount = this.visibleItemCount();
 
     if (itemCount > visibleItemCount) {
-      if (null == dropdownPosition) {
-        switch (selected) {
-          case -1:
-            break;
+      switch (selected) {
+        case -1:
+          break;
 
-          case 0:
-          case 1:
-            break;
+        case 0:
+        case 1:
+          break;
 
-          default:
-            if (selected >= itemCount - tailItemCount) {
-              offset = itemSize * (itemCount - visibleItemCount);
-            } else {
-              offset = itemSize * (selected - 1);
-            }
-        }
-      } else {
-        if (~selected) {
-          if (dropdownPosition < 0) {
-            offset = itemSize * (selected - visibleItemCount - dropdownPosition);
+        default:
+          if (selected >= itemCount - tailItemCount) {
+            offset = itemSize * (itemCount - visibleItemCount);
           } else {
-            offset = itemSize * (selected - dropdownPosition);
+            offset = itemSize * (selected - 1);
           }
-        }
       }
     }
 

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -404,7 +404,7 @@ export default class Dropdown extends PureComponent {
 
   resetScrollOffset() {
     let { selected } = this.state;
-    let { data, dropdownPosition } = this.props;
+    let { data } = this.props;
 
     let offset = 0;
     let itemCount = data.length;


### PR DESCRIPTION
This fixes #76.

I'm not really sure why `dropdownPosition` matters at all when setting the scroll position however this was causing issues for me on iOS. Removing that conditional seems to fix it and not cause any issues on either OS. (Unless of course you had that in there for a reason. 😊)