### PR TITLE
Added ability to set 'disabled: true' for dropdown items as well as...

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,11 +44,14 @@ import { Dropdown } from 'react-native-material-dropdown';
 class Example extends Component {
   render() {
     let data = [{
-      value: 'Banana',
+      label: 'Banana 🍌'
+      value: 'Banana'
     }, {
       value: 'Mango',
+      disabled: true
     }, {
-      value: 'Pear',
+      label: 'Pear 🍐'
+      value: 'Pear'
     }];
 
     return (
@@ -63,37 +66,40 @@ class Example extends Component {
 
 ## Properties
 
- name              | description                                   | type     | default
-:----------------- |:--------------------------------------------- | --------:|:------------------
- label             | Text field label text (required)              |   String | -
- error             | Text field error text                         |   String | -
- animationDuration | Text field animation duration in ms           |   Number | 225
- fontSize          | Text field font size                          |   Number | 16
- labelFontSize     | Text field label font size                    |   Number | 12
- baseColor         | Text field base color                         |   String | rgba(0, 0, 0, .38)
- textColor         | Text field text color                         |   String | rgba(0, 0, 0, .87)
- itemColor         | Dropdown item text color (inactive items)     |   String | rgba(0, 0, 0, .54)
- selectedItemColor | Dropdown item text color (active item)        |   String | rgba(0, 0, 0, .87)
- dropdownPosition  | Dropdown position (dynamic if undefined)      |   Number | -
- itemCount         | Dropdown visible item count                   |   Number | 4
- itemPadding       | Dropdown item vertical padding                |   Number | 8
- itemTextStyle     | Dropdown item text styles                     |   Object | -
- dropdownOffset    | Dropdown offset                               |   Object | { top: 32, left: 0 }
- dropdownMargins   | Dropdown margins                              |   Object | { min: 8, max: 16 }
- data              | Dropdown item data                            |    Array | []
- value             | Selected value                                |   String | -
- containerStyle    | Styles for container view                     |   Object | -
- pickerStyle       | Styles for item picker view                   |   Object | -
- shadeOpacity      | Shade opacity for dropdown items              |   Number | 0.12
- rippleOpacity     | Opacity for ripple effect                     |   Number | 0.54
- rippleInsets      | Insets for ripple on base component           |   Object | { top: 16, bottom: -8 }
- rippleCentered    | Ripple on base component should be centered   |  Boolean | false
- renderBase        | Render base component                         | Function | -
- renderAccessory   | Render text field accessory                   | Function | -
- valueExtractor    | Extract value from item (args: item, index)   | Function | ({ value }) => value
- labelExtractor    | Extract label from item (args: item, index)   | Function | ({ label }) => label
- propsExtractor    | Extract props from item (args: item, index)   | Function | () => null
- onChangeText      | Selection callback (args: value, index, data) | Function | -
+ name                        | description                                   | type     | default
+:--------------------------- |:--------------------------------------------- | --------:|:------------------
+ label                       | Text field label text (required)              |   String | -
+ error                       | Text field error text                         |   String | -
+ animationDuration           | Text field animation duration in ms           |   Number | 225
+ fontSize                    | Text field font size                          |   Number | 16
+ labelFontSize               | Text field label font size                    |   Number | 12
+ baseColor                   | Text field base color                         |   String | rgba(0, 0, 0, .38)
+ textColor                   | Text field text color                         |   String | rgba(0, 0, 0, .87)
+ itemColor                   | Dropdown item text color (inactive items)     |   String | rgba(0, 0, 0, .54)
+ selectedItemColor           | Dropdown item text color (active item)        |   String | rgba(0, 0, 0, .87)
+ disabledItemColor           | Dropdown item text color (disabled item)      |   String | rgba(0, 0, 0, .10)
+ selectedItemBackgroundColor | Dropdown item background color (active item)  |   String | -
+ disabledItemBackgroundColor | Dropdown item background color (disabled item)|   String | -
+ dropdownPosition            | Dropdown position (dynamic if undefined)      |   Number | -
+ itemCount                   | Dropdown visible item count                   |   Number | 4
+ itemPadding                 | Dropdown item vertical padding                |   Number | 8
+ itemTextStyle               | Dropdown item text styles                     |   Object | -
+ dropdownOffset              | Dropdown offset                               |   Object | { top: 32, left: 0 }
+ dropdownMargins             | Dropdown margins                              |   Object | { min: 8, max: 16 }
+ data                        | Dropdown item data                            |    Array | []
+ value                       | Selected value                                |   String | -
+ containerStyle              | Styles for container view                     |   Object | -
+ pickerStyle                 | Styles for item picker view                   |   Object | -
+ shadeOpacity                | Shade opacity for dropdown items              |   Number | 0.12
+ rippleOpacity               | Opacity for ripple effect                     |   Number | 0.54
+ rippleInsets                | Insets for ripple on base component           |   Object | { top: 16, bottom: -8 }
+ rippleCentered              | Ripple on base component should be centered   |  Boolean | false
+ renderBase                  | Render base component                         | Function | -
+ renderAccessory             | Render text field accessory                   | Function | -
+ valueExtractor              | Extract value from item (args: item, index)   | Function | ({ value }) => value
+ labelExtractor              | Extract label from item (args: item, index)   | Function | ({ label }) => label
+ propsExtractor              | Extract props from item (args: item, index)   | Function | () => null
+ onChangeText                | Selection callback (args: value, index, data) | Function | -
 
 Other [TextField][textfield], [TextInput][textinput] and [TouchableWithoutFeedback][touchable] properties will also work
 

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -66,6 +66,8 @@ export default class Dropdown extends PureComponent {
     textColor: 'rgba(0, 0, 0, .87)',
     itemColor: 'rgba(0, 0, 0, .54)',
     baseColor: 'rgba(0, 0, 0, .38)',
+    disabledItemColor: 'rgba(0, 0, 0, .10)',
+    disabledItemBackgroundColor: 'transparent', // Remove react-native-material-buttons's default color
 
     itemCount: 4,
     itemPadding: 8,
@@ -129,8 +131,11 @@ export default class Dropdown extends PureComponent {
 
     textColor: PropTypes.string,
     itemColor: PropTypes.string,
-    selectedItemColor: PropTypes.string,
     baseColor: PropTypes.string,
+    selectedItemColor: PropTypes.string,
+    disabledItemColor: PropTypes.string,
+    selectedItemBackgroundColor: PropTypes.string,
+    disabledItemBackgroundColor: PropTypes.string,
 
     itemTextStyle: Text.propTypes.style,
 
@@ -547,8 +552,11 @@ export default class Dropdown extends PureComponent {
       propsExtractor,
       textColor,
       itemColor,
-      selectedItemColor = textColor,
       baseColor,
+      selectedItemColor = textColor,
+      disabledItemColor,
+      selectedItemBackgroundColor,
+      disabledItemBackgroundColor,
       fontSize,
       itemTextStyle,
       rippleOpacity,
@@ -556,11 +564,16 @@ export default class Dropdown extends PureComponent {
       shadeOpacity,
     } = this.props;
 
+    let isSelected = ~selected && index === selected;
+    let isDisabled = item.disabled || false;
+
     let props = {
       rippleDuration,
       rippleOpacity,
       rippleColor: baseColor,
 
+      color: isSelected ? selectedItemBackgroundColor : null,
+      disabledColor: disabledItemBackgroundColor,
       shadeColor: baseColor,
       shadeOpacity,
 
@@ -573,25 +586,15 @@ export default class Dropdown extends PureComponent {
       },
 
       onPress: this.onSelect,
+      disabled: isDisabled
     };
 
-    if (null == item) {
-      return null;
-    }
+    if (null == item) return null;
 
     let value = valueExtractor(item, index);
     let label = labelExtractor(item, index);
-
-    let title = null == label?
-      value:
-      label;
-
-    let color = ~selected?
-      index === selected?
-        selectedItemColor:
-        itemColor:
-      selectedItemColor;
-
+    let title = null == label ? value : label;
+    let color = isDisabled ? disabledItemColor : isSelected ? selectedItemColor : itemColor;
     let style = { color, fontSize };
 
     return (

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -67,7 +67,6 @@ export default class Dropdown extends PureComponent {
     itemColor: 'rgba(0, 0, 0, .54)',
     baseColor: 'rgba(0, 0, 0, .38)',
     disabledItemColor: 'rgba(0, 0, 0, .10)',
-    disabledItemBackgroundColor: 'transparent', // Remove react-native-material-buttons's default color
 
     itemCount: 4,
     itemPadding: 8,

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -572,8 +572,7 @@ export default class Dropdown extends PureComponent {
       rippleOpacity,
       rippleColor: baseColor,
 
-      color: isSelected ? selectedItemBackgroundColor : null,
-      disabledColor: disabledItemBackgroundColor,
+      color: isDisabled ? disabledItemBackgroundColor : isSelected ? selectedItemBackgroundColor : null,
       shadeColor: baseColor,
       shadeOpacity,
 
@@ -585,8 +584,7 @@ export default class Dropdown extends PureComponent {
         paddingRight: rightInset,
       },
 
-      onPress: this.onSelect,
-      disabled: isDisabled
+      onPress: !isDisabled ? this.onSelect : null
     };
 
     if (null == item) return null;


### PR DESCRIPTION
…`disabledItemColor`, `selectedItemBackgroundColor`, and `disabledItemBackgroundColor` props.

This closes #79.

You can now do something like this:

```javascript
import React, { Component } from 'react';
import { Dropdown } from 'react-native-material-dropdown';

class Example extends Component {
  render() {
    let data = [{
      label: 'Banana 🍌'
      value: 'Banana'
    }, {
      value: 'Mango',
      disabled: true
    }, {
      label: 'Pear 🍐'
      value: 'Pear'
    }];

    return (
      <Dropdown
        label='Favorite Fruit'
        data={data}
        itemColor='#fff'
        selectedItemColor='#fff'
        disabledItemColor='rgba(0, 0, 0, 0.75)'
        selectedItemBackgroundColor='rgba(0, 0, 0, 0.25)'
        disabledItemBackgroundColor='rgba(255, 255, 255, 0.25)'
      />
    );
  }
}
```