### PR TITLE
useNativeDriver

### DIFF
--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -293,6 +293,7 @@ export default class Dropdown extends PureComponent {
             .timing(opacity, {
               duration: animationDuration,
               toValue: 1,
+              useNativeDriver: true,
             })
             .start(() => {
               if (this.mounted && 'ios' === Platform.OS) {
@@ -316,6 +317,7 @@ export default class Dropdown extends PureComponent {
       .timing(opacity, {
         duration: animationDuration,
         toValue: 0,
+        useNativeDriver: true,
       })
       .start(() => {
         this.focused = false;


### PR DESCRIPTION
There is IMHO no reason not to use the native driver for opacity animations as they are supported correctly

This makes the animation smooth on Android in __DEV__ mode, otherwise they are flickering, and this is also better for prod