### PR TITLE
Fix onSelect close delay

### DIFF
--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -335,9 +335,8 @@ export default class Dropdown extends PureComponent {
     let { data, valueExtractor, onChangeText } = this.props;
 
     let item = data[index];
-    let itemProps = this.getItemProps(item,index);
+    let {rippleDuration} = this.getItemProps(item,index);
     let value = valueExtractor(data[index], index);
-    let itemRippleDuration = itemProps.rippleDuration;
 
     this.setState({ value });
 
@@ -345,8 +344,8 @@ export default class Dropdown extends PureComponent {
       onChangeText(value, index, data);
     }
 
-    itemRippleDuration > 0 ?
-      setTimeout(this.onClose, itemRippleDuration) :
+    rippleDuration > 0 ?
+      setTimeout(this.onClose, rippleDuration) :
       this.onClose();
   }
 

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -165,6 +165,7 @@ export default class Dropdown extends PureComponent {
 
     this.renderAccessory = this.renderAccessory.bind(this);
     this.renderItem = this.renderItem.bind(this);
+    this.getItemProps = this.getItemProps.bind(this);
 
     this.keyExtractor = this.keyExtractor.bind(this);
 
@@ -331,8 +332,12 @@ export default class Dropdown extends PureComponent {
   }
 
   onSelect(index) {
-    let { data, valueExtractor, onChangeText, animationDuration } = this.props;
+    let { data, valueExtractor, onChangeText } = this.props;
+
+    let item = data[index];
+    let itemProps = this.getItemProps(item,index);
     let value = valueExtractor(data[index], index);
+    let itemRippleDuration = itemProps.rippleDuration;
 
     this.setState({ value });
 
@@ -340,7 +345,9 @@ export default class Dropdown extends PureComponent {
       onChangeText(value, index, data);
     }
 
-    setTimeout(this.onClose, animationDuration);
+    itemRippleDuration > 0 ?
+      setTimeout(this.onClose, itemRippleDuration) :
+      this.onClose();
   }
 
   onLayout(event) {
@@ -538,42 +545,47 @@ export default class Dropdown extends PureComponent {
     );
   }
 
+  getItemProps(item,index) {
+    let { leftInset, rightInset } = this.state;
+    let {
+      propsExtractor,
+      baseColor,
+      rippleOpacity,
+      rippleDuration,
+      shadeOpacity,
+    } = this.props;
+
+    return {
+      rippleDuration,
+      rippleOpacity,
+      rippleColor: baseColor,
+      shadeColor: baseColor,
+      shadeOpacity,
+      ...propsExtractor(item, index),
+      style: {
+        height: this.itemSize(),
+        paddingLeft: leftInset,
+        paddingRight: rightInset,
+      },
+      onPress: this.onSelect,
+    };
+  }
+
   renderItem({ item, index }) {
     let { selected, leftInset, rightInset } = this.state;
 
     let {
       valueExtractor,
       labelExtractor,
-      propsExtractor,
       textColor,
       itemColor,
       selectedItemColor = textColor,
       baseColor,
       fontSize,
       itemTextStyle,
-      rippleOpacity,
-      rippleDuration,
-      shadeOpacity,
     } = this.props;
 
-    let props = {
-      rippleDuration,
-      rippleOpacity,
-      rippleColor: baseColor,
-
-      shadeColor: baseColor,
-      shadeOpacity,
-
-      ...propsExtractor(item, index),
-
-      style: {
-        height: this.itemSize(),
-        paddingLeft: leftInset,
-        paddingRight: rightInset,
-      },
-
-      onPress: this.onSelect,
-    };
+    let props = this.getItemProps(item,index);
 
     if (null == item) {
       return null;

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -571,7 +571,7 @@ export default class Dropdown extends PureComponent {
   }
 
   renderItem({ item, index }) {
-    let { selected, leftInset, rightInset } = this.state;
+    let { selected } = this.state;
 
     let {
       valueExtractor,
@@ -579,7 +579,6 @@ export default class Dropdown extends PureComponent {
       textColor,
       itemColor,
       selectedItemColor = textColor,
-      baseColor,
       fontSize,
       itemTextStyle,
     } = this.props;


### PR DESCRIPTION
onSelect close delay should be driven by item ripple duration: the dropdown should start disappear just after the item ripple effect ends instead of using the animationDuration as a delay.

Currently if user use rippleDuration=0, the behavior is that when pressing a dropdown item, there is a 225ms delay for no reason and no user feedback at all which is confusing