### PR TITLE
Add numberOfLines as a prop for the dropdown text

### DIFF
--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -505,7 +505,6 @@ export default class Dropdown extends PureComponent {
       title:
       String(title);
       delete props.disabled;
-      const inputContainerStyle = this.props.disabled ? { borderBottomWidth: 0 } : {};
     return (
       <TextField
         label=''
@@ -517,7 +516,7 @@ export default class Dropdown extends PureComponent {
         editable={false}
         onChangeText={undefined}
         renderAccessory={this.props.disabled ? undefined : renderAccessory}
-        inputContainerStyle={inputContainerStyle}
+        inputContainerStyle={{ borderBottomWidth: 0 }}
       />
     );
   }

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -503,7 +503,8 @@ export default class Dropdown extends PureComponent {
     title = null == title || 'string' === typeof title?
       title:
       String(title);
-
+      delete props.disabled;
+      const inputContainerStyle = this.props.disabled ? { borderBottomWidth: 0 } : {};
     return (
       <TextField
         label=''
@@ -514,7 +515,8 @@ export default class Dropdown extends PureComponent {
         value={title}
         editable={false}
         onChangeText={undefined}
-        renderAccessory={renderAccessory}
+        renderAccessory={this.props.disabled ? undefined : renderAccessory}
+        inputContainerStyle={inputContainerStyle}
       />
     );
   }

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -66,6 +66,7 @@ export default class Dropdown extends PureComponent {
     textColor: 'rgba(0, 0, 0, .87)',
     itemColor: 'rgba(0, 0, 0, .54)',
     baseColor: 'rgba(0, 0, 0, .38)',
+    numberOfLines: 1,
 
     itemCount: 4,
     itemPadding: 8,
@@ -131,6 +132,7 @@ export default class Dropdown extends PureComponent {
     itemColor: PropTypes.string,
     selectedItemColor: PropTypes.string,
     baseColor: PropTypes.string,
+    numberOfLines: PropTypes.number,
 
     itemTextStyle: Text.propTypes.style,
 
@@ -385,9 +387,9 @@ export default class Dropdown extends PureComponent {
   }
 
   itemSize() {
-    let { fontSize, itemPadding } = this.props;
+    let { fontSize, itemPadding, numberOfLines } = this.props;
 
-    return Math.ceil(fontSize * 1.5 + itemPadding * 2);
+    return Math.ceil(fontSize * 1.5 * numberOfLines + itemPadding * 2);
   }
 
   visibleItemCount() {
@@ -610,7 +612,7 @@ export default class Dropdown extends PureComponent {
 
     return (
       <DropdownItem index={index} {...props}>
-        <Text style={[styles.item, itemTextStyle, style]} numberOfLines={1}>
+        <Text style={[styles.item, itemTextStyle, style]} numberOfLines={props.numberOfLines}>
           {title}
         </Text>
       </DropdownItem>


### PR DESCRIPTION
If dropdown options are too long, they are shown with an ellipses.  This option allows you to specify that you want multiple lines of text to show.