### PR TITLE
check if user wants a label before asign value as label

### DIFF
--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -482,6 +482,7 @@ export default class Dropdown extends PureComponent {
       labelExtractor,
       dropdownOffset,
       renderAccessory = this.renderAccessory,
+      initialValueLabel
     } = this.props;
 
     let index = this.selectedIndex();
@@ -491,7 +492,9 @@ export default class Dropdown extends PureComponent {
       title = labelExtractor(data[index], index);
     }
 
-    if (null == title) {
+    if(initialValueLabel){
+      title = initialValueLabel
+    } else if (null == title) {
       title = value;
     }
 


### PR DESCRIPTION
When a form has pre filled values, instead of assigning the value to title by default, checks initialValueLabel  prop first for an initial title.