### PR TITLE
Added lineWidth prop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@ class Example extends Component {
  labelExtractor    | Extract label from item (args: item, index)   | Function | ({ label }) => label
  propsExtractor    | Extract props from item (args: item, index)   | Function | () => null
  onChangeText      | Selection callback (args: value, index, data) | Function | -
+ lineWidth         | Text field underline width                    | Number   | 0.5
 
 Other [TextField][textfield], [TextInput][textinput] and [TouchableWithoutFeedback][touchable] properties will also work
 

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -76,6 +76,8 @@ export default class Dropdown extends PureComponent {
     ],
 
     useNativeDriver: false,
+
+    lineWidth: 0.5,
   };
 
   static propTypes = {
@@ -153,6 +155,8 @@ export default class Dropdown extends PureComponent {
     supportedOrientations: PropTypes.arrayOf(PropTypes.string),
 
     useNativeDriver: PropTypes.bool,
+
+    lineWidth: PropTypes.number
   };
 
   constructor(props) {
@@ -510,6 +514,7 @@ export default class Dropdown extends PureComponent {
 
         {...props}
 
+        lineWidth={this.props.lineWidth}
         value={title}
         editable={false}
         onChangeText={undefined}


### PR DESCRIPTION
- Added lineWidth prop so that the TextFields underline can be modified.
- 0.5 used as default value (taken from `react-native-material-textfield`)
- Updated README